### PR TITLE
修改源代码‘https?’改为‘https’，删除curl部分，直接使用wget

### DIFF
--- a/ssr-decode
+++ b/ssr-decode
@@ -8,7 +8,8 @@
 #
 # Requirements: base64, curl/wget (optional)
 
-local_port=${LOCAL_PORT:-1080}
+##只有ss类型需要本地端口吗？没发现有用，自己随便设置
+local_port=${LOCAL_PORT:-1080}  
 timeout=${TIMEOUT:-300}
 
 decode_base64() {
@@ -90,6 +91,8 @@ decode_link() {
 	esac
 }
 
+##主程序位置，$#代表传入参数个数，$1代表第一个参数，我的订阅链接使用0个参数，手动输入链接能下载识别，直接输入第一个参数却不能完全识别链接地址，在&后识别不了
+##使用sh ssr-decode "https://" 能正常解析使用
 if [ "$#" = 1 ] && [ "$1" = "-h" ]; then
 	echo "Usage: ssr-decode [ (http|https|ss|ssr|vmess):// | BASE64 | < input.txt ]"
 elif [ "$#" = 0 ]; then

--- a/ssr-decode
+++ b/ssr-decode
@@ -85,7 +85,7 @@ decode_link() {
 		ss)     decode_ss "$info" ;;
 		ssr)    decode_ssr "$info" ;;
 		vmess)  decode_vmess "$info" ;;
-		https?) decode_link "$(curl -Ss "$1" || wget -qO - "$1")" ;;
+		https) decode_link "$(wget -qO - "$1")" ;;
 		*)      for link in $info; do decode_link "$link"; done ;;
 	esac
 }


### PR DESCRIPTION
使得https为参数的订阅链接能够正常下载运行，我的订阅链接使用curl命令不能读取正确读取网址并下载，所以删除curl，只是用wget方法